### PR TITLE
Add tests for useRefreshToken

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -13,6 +13,7 @@ const envVars = Object.keys(parsed).reduce<Record<string, string>>(
 const config: Config = {
   testEnvironment: "jest-environment-jsdom",
   setupFilesAfterEnv: ["<rootDir>/tests/unit/setupTests.ts"],
+  testMatch: ["<rootDir>/tests/unit/**/*.spec.ts?(x)"], // directories to find tests
   verbose: true,
   transform: {
     "^.+\\.(t|j)sx?$": [

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -1,26 +1,30 @@
 {
   "packageManager": "npm",
-  "tempDirName": "tests/mutation/tmp",
   "testRunner": "jest",
-  "tsconfigFile": "tsconfig.json",
   "jest": {
     "configFile": "jest.config.ts"
   },
+  "tempDirName": "./tests/mutation/tmp",
+  "tsconfigFile": "./tsconfig.json",
   "incremental": true,
-  "incrementalFile": "tests/mutation/stryker-incremental.json",
+  "incrementalFile": "./tests/mutation/stryker-incremental.json",
   "disableTypeChecks": true,
-  "mutate": ["src/**/*.ts?(x)", "!src/{assets,types,api}/**/*"],
+  "mutate": [
+    "./src/**/*.ts?(x)",
+    "!./src/**/*.styled.ts?(x)",
+    "!./src/{api,assets,types}/**/*"
+  ],
   "mutator": {
     "excludedMutations": ["StringLiteral", "ArrayDeclaration"]
   },
   "ignoreStatic": true,
-  "reporters": ["progress", "html", "json"],
   "coverageAnalysis": "perTest",
+  "reporters": ["progress", "html", "json"],
   "cleanTempDir": true,
   "htmlReporter": {
-    "fileName": "tests/mutation/reports/stryker.html"
+    "fileName": "./tests/mutation/reports/stryker.html"
   },
   "jsonReporter": {
-    "fileName": "tests/mutation/reports/stryker.json"
+    "fileName": "./tests/mutation/reports/stryker.json"
   }
 }

--- a/tests/unit/src/hooks/auth/useRefreshToken.spec.ts
+++ b/tests/unit/src/hooks/auth/useRefreshToken.spec.ts
@@ -1,0 +1,131 @@
+import { renderHook, waitFor } from "@testing-library/react";
+
+import useRefreshToken from "@/hooks/auth/useRefreshToken";
+import fetchAccessToken from "@/utils/fetchAccessToken";
+import showSnackbar from "@/utils/showSnackbar";
+
+const mockShowSnackbar = jest.fn();
+const mockFetchAccessToken = jest.fn();
+const mockSetAccessToken = jest.fn();
+const mockSetIsAuthenticating = jest.fn();
+const mockAbort = jest.fn();
+
+jest.mock("@/utils/showSnackbar", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("@/utils/fetchAccessToken", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("@/store/user/userStore", () => ({
+  useUserStore: jest.fn(fn => {
+    const data = {
+      setAccessToken: mockSetAccessToken,
+      setIsAuthenticating: mockSetIsAuthenticating,
+    };
+
+    return fn(data);
+  }),
+}));
+
+const createAbortError = () => {
+  const error = new Error("Request was aborted");
+  error.name = "AbortError";
+  return error;
+};
+
+const createMockAbortController = (aborted?: boolean): jest.Mock => {
+  return jest.fn(() => ({
+    abort: mockAbort,
+    signal: { aborted },
+  }));
+};
+
+type RenderAndMock = {
+  aborted?: boolean;
+  hasNonAbortError?: boolean;
+};
+
+const renderAndMock = ({
+  aborted = false,
+  hasNonAbortError,
+}: RenderAndMock = {}) => {
+  (fetchAccessToken as jest.Mock).mockImplementation(mockFetchAccessToken);
+  (showSnackbar as jest.Mock).mockImplementation(mockShowSnackbar);
+
+  global.AbortController = createMockAbortController(aborted);
+
+  if (aborted) {
+    mockFetchAccessToken.mockRejectedValueOnce(createAbortError());
+  } else if (hasNonAbortError) {
+    mockFetchAccessToken.mockRejectedValueOnce(new Error());
+  } else {
+    mockFetchAccessToken.mockImplementationOnce(() => {
+      return Promise.resolve({
+        json: () => Promise.resolve({ accessToken: "mockToken" }),
+      });
+    });
+  }
+
+  return renderHook(() => useRefreshToken());
+};
+
+describe("useRefreshToken()", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call abort on unmount", () => {
+    const { unmount } = renderAndMock();
+    unmount();
+    expect(mockAbort).toHaveBeenCalled();
+  });
+
+  it("should set access token when request is successfull", async () => {
+    renderAndMock();
+
+    expect(mockFetchAccessToken).toHaveBeenCalledWith({
+      signal: { aborted: false },
+    });
+
+    await waitFor(() => {
+      expect(mockSetAccessToken).toHaveBeenCalledWith("mockToken");
+    });
+  });
+
+  describe("with abort", () => {
+    beforeEach(() => {
+      renderAndMock({ aborted: true });
+      expect(mockSetIsAuthenticating).toHaveBeenCalledWith(true);
+    });
+
+    it("should not call showSnackbar when request is aborted", async () => {
+      await waitFor(() => {
+        expect(mockShowSnackbar).not.toHaveBeenCalled();
+        expect(mockSetAccessToken).not.toHaveBeenCalled();
+      });
+    });
+
+    it("should not reset authenticated when request is aborted", async () => {
+      await waitFor(() => {
+        expect(mockSetIsAuthenticating).not.toHaveBeenCalledWith(false);
+      });
+    });
+  });
+
+  it("should call showSnackbar when request failed but not aborted", async () => {
+    renderAndMock({ hasNonAbortError: true });
+
+    await waitFor(() => {
+      expect(mockShowSnackbar).toHaveBeenCalledWith({
+        autohide: true,
+        message: "User is not logged in",
+      });
+      expect(mockSetAccessToken).toHaveBeenCalledWith(null);
+      expect(mockSetIsAuthenticating).toHaveBeenCalledWith(false);
+    });
+  });
+});


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5717df6c-b391-44dd-826c-6d82edc975e4)

![image](https://github.com/user-attachments/assets/c53f9492-10ec-48e5-9e0c-1156bb453d62)

Additional changes are:
- Add `testMatch` option to avoid running unit tests from mutation folder
- Fixed `stryker.conf.json` to resemble same path structure